### PR TITLE
Remove incompatible characters in art filename

### DIFF
--- a/UeberPlayer.widget/getTrack.scpt
+++ b/UeberPlayer.widget/getTrack.scpt
@@ -77,6 +77,7 @@ if playingState and my songChanged() then
     if appName is "Spotify" then
       my extractSpotifyArt()
     else if appName is "Music" then
+    log "extract"
       my extractMusicArt()
     end if
   else    -- Else, touch the cached file to keep it "fresh"
@@ -145,7 +146,7 @@ on generateArtFilename(str)
   set charsToCheck to characters of str
   set retList to {}
   repeat with i from 1 to count charsToCheck
-    if {charsToCheck's item i} is not in {" ", "\""} then
+    if {charsToCheck's item i} is not in {" ", "\"", "/", ",", ":", "?"} then
       set retList's end to charsToCheck's item i
     end if
   end repeat


### PR DESCRIPTION
While using the widget, I noticed that some song and album names were generating "invalid" filenames for the artwork, resulting in the cover not being shown at all. 

This fixes it by adding `, \ : ?` to the list of character to exclude when generating the artwork filename.